### PR TITLE
Fix missing tenant in related_query/2 of ArchiveRelated

### DIFF
--- a/lib/ash_archival/resource/changes/archive_related.ex
+++ b/lib/ash_archival/resource/changes/archive_related.ex
@@ -92,7 +92,7 @@ defmodule AshArchival.Resource.Changes.ArchiveRelated do
         |> Map.put(:ash_archival, true)
         |> Ash.Helpers.deep_merge_maps(relationship.context || %{})
 
-      case related_query(data, relationship) do
+      case related_query(data, relationship, opts) do
         {:ok, query} ->
           Ash.bulk_destroy!(
             query,
@@ -130,11 +130,11 @@ defmodule AshArchival.Resource.Changes.ArchiveRelated do
   # allowing us not to fetch this relationship in the case that data layers
   # support lateral joining. Not sure if this would "just work" to be paired
   # with `update_query` or if we would need a separate callback.
-  defp related_query(_records, %{type: :many_to_many}) do
+  defp related_query(_records, %{type: :many_to_many}, _opts) do
     :error
   end
 
-  defp related_query(records, relationship) do
+  defp related_query(records, relationship, opts) do
     if Ash.Actions.Read.Relationships.has_parent_expr?(relationship) do
       :error
     else
@@ -148,7 +148,8 @@ defmodule AshArchival.Resource.Changes.ArchiveRelated do
        |> elem(1)
        |> filter_by_keys(relationship, records)
        |> Ash.Query.set_context(%{ash_archival: true})
-       |> Ash.Query.set_context(relationship.context || %{})}
+       |> Ash.Query.set_context(relationship.context || %{})
+       |> Ash.Query.set_tenant(opts[:tenant])}
     end
   end
 


### PR DESCRIPTION
This PR fixes a bug in ash_archival where the query for archiving relationships is created without setting the tenant.

The issue I’m currently facing occurs when a policy relies on the tenant value from the context. Specifically, in the flow of ash_archival’s bulk destroy → bulk update → authorize_bulk_query, the policy fails due to the missing tenant.

I’d like to add a test for this, but I’m not sure how best to set up a multitenant test case, so I’m opening the PR without one for now.

### Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
