### PR TITLE
bug(ArchiveRelated): Reproduce bug in related archives.

### DIFF
--- a/test/support/post/archival.ex
+++ b/test/support/post/archival.ex
@@ -1,4 +1,5 @@
 defmodule AshArchival.Test.Post.Archival do
+  @moduledoc false
   use Spark.Dsl.Fragment,
     of: Ash.Resource,
     extensions: [AshArchival.Resource]


### PR DESCRIPTION
For some reason the read action being used by the relationship is not being correctly authorized by the bulk destroy within the archive related change.

I tried to run this down in Ash, but I couldn't figure out the combination of factors that was causing this.

Related to APS ticket number 328.