### PR TITLE
fix link to How Does Ash Archival Work

### DIFF
--- a/documentation/tutorials/get-started-with-ash-archival.md
+++ b/documentation/tutorials/get-started-with-ash-archival.md
@@ -25,7 +25,7 @@ use Ash.Resource,
 
 And thats it! Now, when you destroy a record, it will be archived instead, using an `archived_at` attribute.
 
-See [How Does Ash Archival Work?](/documentation/tutorials/get-started-with-ash-archival.md) for what modifications are made to a resource, and read on for info on the tradeoffs of leveraging `d:Ash.Resource.Dsl.resource.base_filter`.
+See [How Does Ash Archival Work?](/documentation/topics/how-does-ash-archival-work.md) for what modifications are made to a resource, and read on for info on the tradeoffs of leveraging `d:Ash.Resource.Dsl.resource.base_filter`.
 
 ## Base Filter
 


### PR DESCRIPTION
I noticed the link in https://hexdocs.pm/ash_archival/get-started-with-ash-archival.html#adding-to-a-resource was pointing to the page I was already on, but figured out where it was supposed to go.

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
